### PR TITLE
Fix Handshake Failure

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
 
         // LibP2P Core Modules
-        .package(url: "https://github.com/swift-libp2p/swift-libp2p", .upToNextMinor(from: "0.3.0")),
+        .package(url: "https://github.com/swift-libp2p/swift-libp2p", .upToNextMinor(from: "0.3.1")),
 
         // MPLEX for testing
         .package(url: "https://github.com/swift-libp2p/swift-libp2p-mplex", .upToNextMinor(from: "0.2.0")),

--- a/Package.swift
+++ b/Package.swift
@@ -31,7 +31,7 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
 
-        // LibP2P Core Modules
+        // LibP2P Modules
         .package(url: "https://github.com/swift-libp2p/swift-libp2p", .upToNextMinor(from: "0.3.1")),
 
         // MPLEX for testing

--- a/Sources/LibP2PPlaintext/ChannelHandlers/HandshakeHandler.swift
+++ b/Sources/LibP2PPlaintext/ChannelHandlers/HandshakeHandler.swift
@@ -1,0 +1,262 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the swift-libp2p open source project
+//
+// Copyright (c) 2022-2025 swift-libp2p project authors
+// Licensed under MIT
+//
+// See LICENSE for license information
+// See CONTRIBUTORS for the list of swift-libp2p project authors
+//
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+import LibP2P
+import NIOConcurrencyHelpers
+
+/// Plaintext V2
+///
+/// https://github.com/libp2p/specs/blob/master/plaintext/README.md
+/// Version 2.0.0 (PeerID Exchange)
+///
+/// Misc Notes:
+/// PlaintextV2 DOES NOT Require uVarInt length based frame encoding/decoding
+/// The handshake / peerID exchange is uVarInt prefixed, but after that, it should simply forward data along.
+internal final class PlaintextV2HandshakeHandler: ChannelInboundHandler, RemovableChannelHandler, Sendable {
+    public typealias InboundIn = ByteBuffer
+    public typealias InboundOut = ByteBuffer
+    public typealias OutboundOut = ByteBuffer
+
+    private enum State: Sendable {
+        case awaitingPeerID
+        case verified
+    }
+
+    private let channelSecuredCallback: EventLoopPromise<Connection.SecuredResult>
+
+    private var state: State {
+        get { _state.withLockedValue { $0 } }
+        set { _state.withLockedValue { $0 = newValue } }
+    }
+    private let _state: NIOLockedValueBox<State>
+
+    private let logger: Logger
+    private let localPeerInfo: PeerID
+
+    private var remotePeerInfo: PeerID? {
+        get { _remotePeerInfo.withLockedValue { $0 } }
+        set { _remotePeerInfo.withLockedValue { $0 = newValue } }
+    }
+    private let _remotePeerInfo: NIOLockedValueBox<PeerID?>
+    private let expectedRemotePeerID: PeerID?
+
+    private var buffer: [UInt8] {
+        get { _buffer.withLockedValue { $0 } }
+        set { _buffer.withLockedValue { $0 = newValue } }
+    }
+    private let _buffer: NIOLockedValueBox<[UInt8]>
+
+    private var shouldWarn: Bool {
+        get { _shouldWarn.withLockedValue { $0 } }
+        set { _shouldWarn.withLockedValue { $0 = newValue } }
+    }
+    private let _shouldWarn: NIOLockedValueBox<Bool> = .init(false)
+
+    let mode: LibP2PCore.Mode
+
+    public init(
+        peerID: PeerID,
+        mode: LibP2PCore.Mode,
+        logger: Logger,
+        secured: EventLoopPromise<Connection.SecuredResult>,
+        expectedRemotePeerID: PeerID?
+    ) {
+        var logger = logger
+        logger[metadataKey: "PlaintextV2"] = .string("handshake.\(mode.rawValue)")
+        self.logger = logger
+
+        self.mode = mode
+        self.localPeerInfo = peerID
+        self._remotePeerInfo = .init(nil)
+        self.expectedRemotePeerID = expectedRemotePeerID
+        self._state = .init(.awaitingPeerID)
+        self.channelSecuredCallback = secured
+        self._buffer = .init([])
+    }
+
+    /// We take this opportunity to send our PeerExchange protobuf
+    public func handlerAdded(context: ChannelHandlerContext) {
+        do {
+            self.logger.trace("Sending our local peer info to remote peer")
+
+            /// ----------------- Support Go ----------------
+            let peerInfo = try self.localPeerInfo.marshal()
+            /// ---------------------------
+
+            /// ----------------- Support JS ----------------
+            //let peerInfo = try createExchangeMessage(localPeerInfo)
+            /// ---------------------------
+
+            let payload = putUVarInt(UInt64(peerInfo.count)) + peerInfo
+
+            self.logger.trace("\(payload.asString(base: .base16))")
+            self.logger.trace("Count: \(payload.count)")
+
+            // Write the serialized data to a buffer
+            let buf = context.channel.allocator.buffer(bytes: payload)
+
+            // Send our peer info off to the remote host...
+            context.writeAndFlush(self.wrapOutboundOut(buf), promise: nil)
+
+        } catch {
+            self.logger.error("Failed to instantiate our PeerInfo Exchange protobuf")
+            self.logger.error("Error: \(error)")
+            self.logger.error("Closing Channel")
+            // TODO: We should probably fail better than this...
+            channelSecuredCallback.fail(error)
+            context.fireErrorCaught(error)
+            context.close(mode: .all, promise: nil)
+        }
+    }
+
+    public func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+        switch state {
+        case .awaitingPeerID:
+            //We're expecting an Exchange Protobuf object thats uVarInt length Prefixed, if it's not that then we abort...
+            let buf = unwrapInboundIn(data)
+
+            let msg = buffer + [UInt8](buf.readableBytesView)
+            let prefix = uVarInt(msg)
+            guard prefix.bytesRead > 0, prefix.value > 1 else {
+                self.logger.error("Failed to parse inbound Plaintext/2.0.0 Handshake message")
+                channelSecuredCallback.fail(PlaintextUpgrader.Error.invalidPeerIDExchange)
+                return context.close(mode: .all, promise: nil)
+            }
+
+            if prefix.value > msg.count {
+                //Partial Read Detected, waiting for more info!
+                buffer = msg
+                return
+            }
+
+            //msg = Array(msg.dropFirst(prefix.bytesRead))
+            let peerInfo = Array(msg[prefix.bytesRead..<(prefix.bytesRead + Int(prefix.value))])
+            let leftoverData = msg[(prefix.bytesRead + Int(prefix.value))...]
+
+            do {
+                logger.trace("\(peerInfo.asString(base: .base16))")
+                logger.trace("Bytes: \(peerInfo.count)")
+
+                let exchangeMessage = try Exchange(serializedBytes: peerInfo)
+                if let pid = try? PeerID(marshaledPeerID: Data(peerInfo)) {
+                    self.logger.trace("Incoming Message straight to PeerID (no exchange proto) => \(pid.b58String)")
+                    remotePeerInfo = pid
+                } else {
+                    remotePeerInfo = try PeerID(marshaledPublicKey: exchangeMessage.pubkey.data)  //.serializedData())
+                }
+
+                guard remotePeerInfo!.id == exchangeMessage.id.byteArray else {
+                    logger.error("Remote Peer ID isn't derived from their PublicKey. Closing connection.")
+                    self.channelSecuredCallback.fail(PlaintextUpgrader.Error.invalidPeerIDExchange)
+                    return context.close(mode: .all, promise: nil)
+                }
+                if let expectedRemotePeerID {
+                    guard expectedRemotePeerID == remotePeerInfo else {
+                        logger.error("Remote Peer ID doesn't match our expected Peer ID. Closing connection.")
+                        self.channelSecuredCallback.fail(PlaintextUpgrader.Error.unexpectedRemotePeer)
+                        return context.close(mode: .all, promise: nil)
+                    }
+                } else {
+                    self._shouldWarn.withLockedValue { $0 = true }
+                    logger.warning("Skipping Remote PeerID check as Expected PeerID was not provided")
+                }
+                logger.trace("Peer Info from Remote Peer seems legit, let's proceed")
+                logger.trace("PeerID: \(remotePeerInfo!.b58String)")
+                // Construct the Multiaddr that we know so far...
+                logger.trace(
+                    "RemoteAddress:Protocol => \(String(describing: context.channel.remoteAddress?.protocol ?? .none))"
+                )
+                logger.trace("RemoteAddress:Protocol => \(context.channel.remoteAddress?.ipAddress ?? "nil")")
+                logger.trace("RemoteAddress:Protocol => \(context.channel.remoteAddress?.port ?? -1)")
+                logger.trace("RemoteAddress:Protocol => \(context.channel.remoteAddress?.pathname ?? "nil")")
+
+                // Upgrade our state so that all future messages will be propogated through the pipeline
+                state = .verified
+
+                let extraData = context.channel.allocator.buffer(bytes: leftoverData)
+
+                // Now that our Handshake has completed successfully we
+                // - install our Encyrption & Decryption handlers
+                // - remove this handler from the pipeline
+                // - complete our channelSecureCallback so our Channel is notified of the result
+                channelSecuredCallback.completeWith(
+                    context.pipeline.addHandlers(
+                        [
+                            //Inbound Decryption Handler
+                            InboundPlaintextV2DencryptHandler(
+                                mode: self.mode,
+                                extraData: extraData,
+                                logger: self.logger
+                            ),
+                            //Outbound Encryption Handler
+                            OutboundPlaintextV2EncryptHandler(
+                                mode: self.mode,
+                                logger: self.logger
+                            ),
+                        ],
+                        position: .after(self)
+                    ).flatMap { _ -> EventLoopFuture<Connection.SecuredResult> in
+                        self.logger.trace(
+                            "Encryption and Decryption Handlers Installed! Uninstalling self (handshake handler)"
+                        )
+                        return context.pipeline.removeHandler(self).map { _ -> Connection.SecuredResult in
+                            self.logger.debug("Channel Secured 🔐")
+                            return (
+                                PlaintextUpgrader.key,
+                                remotePeer: self.remotePeerInfo,
+                                warning: self.shouldWarn ? SecurityWarnings.skippedRemotePeerValidation : nil
+                            )
+                        }
+                    }
+                )
+
+            } catch {
+                logger.error("Failed to instantiate an Exchange Protobuf from the inbound data")
+                logger.error("Error: \(error)")
+                channelSecuredCallback.fail(error)
+                context.close(mode: .all, promise: nil)
+            }
+        case .verified:
+            self.logger.error("We should be removed at this point")
+            context.fireChannelRead(wrapInboundOut(unwrapInboundIn(data)))
+        }
+    }
+
+    /// Given a peerID, this method handles building an Exchange protobuf
+    private func createExchangeMessage(_ peerID: PeerID) throws -> Data {
+        let keyType: Exchange.KeyType
+        switch peerID.keyPair!.keyType {
+        case .rsa:
+            keyType = .rsa
+        case .ed25519:
+            keyType = .ed25519
+        case .secp256k1:
+            keyType = .secp256K1
+        }
+
+        var pubkey = Exchange.PublicKey()
+        pubkey.type = keyType
+        pubkey.data = try Data(peerID.marshalPublicKey())
+
+        var exch = Exchange()
+        exch.id = Data(peerID.id)
+        exch.pubkey = pubkey
+
+        return try exch.serializedData()
+    }
+
+    public enum Errors: Error {
+        case failedToRemoveEphemeralHandshakeHandlersFromPipeline
+    }
+}

--- a/Sources/LibP2PPlaintext/ChannelHandlers/InboundHandler.swift
+++ b/Sources/LibP2PPlaintext/ChannelHandlers/InboundHandler.swift
@@ -13,221 +13,45 @@
 //===----------------------------------------------------------------------===//
 
 import LibP2P
-import NIOConcurrencyHelpers
 
-/// Plaintext V2
-///
-/// https://github.com/libp2p/specs/blob/master/plaintext/README.md
-/// Version 2.0.0 (PeerID Exchange)
-///
-/// Misc Notes:
-/// PlaintextV2 DOES NOT Require uVarInt length based frame encoding/decoding
-/// The handshake / peerID exchange is uVarInt prefixed, but after that, it should simply forward data along.
-internal final class InboundPlaintextV2DecryptHandler: ChannelInboundHandler, Sendable {
+// Version 2.0.0 (PeerID Exchange)
+internal final class InboundPlaintextV2DencryptHandler: ChannelInboundHandler, Sendable {
     public typealias InboundIn = ByteBuffer
     public typealias InboundOut = ByteBuffer
-    public typealias OutboundOut = ByteBuffer
 
-    private enum State: Sendable {
-        case awaitingPeerID
-        case verified
-    }
-
-    private let channelSecuredCallback: EventLoopPromise<Connection.SecuredResult>
-
-    private var state: State {
-        get { _state.withLockedValue { $0 } }
-        set { _state.withLockedValue { $0 = newValue } }
-    }
-    private let _state: NIOLockedValueBox<State>
-
+    private let extraData: ByteBuffer
     private let logger: Logger
-    private let localPeerInfo: PeerID
 
-    private var remotePeerInfo: PeerID? {
-        get { _remotePeerInfo.withLockedValue { $0 } }
-        set { _remotePeerInfo.withLockedValue { $0 = newValue } }
-    }
-    private let _remotePeerInfo: NIOLockedValueBox<PeerID?>
-    private let expectedRemotePeerID: PeerID?
-
-    private var buffer: [UInt8] {
-        get { _buffer.withLockedValue { $0 } }
-        set { _buffer.withLockedValue { $0 = newValue } }
-    }
-    private let _buffer: NIOLockedValueBox<[UInt8]>
-
-    public init(
-        peerID: PeerID,
-        mode: LibP2PCore.Mode,
-        logger: Logger,
-        secured: EventLoopPromise<Connection.SecuredResult>,
-        expectedRemotePeerID: PeerID?
-    ) {
+    public init(mode: LibP2PCore.Mode, extraData: ByteBuffer, logger: Logger) {
         var logger = logger
         logger[metadataKey: "PlaintextV2"] = .string("inbound.\(mode.rawValue)")
 
+        self.extraData = extraData
         self.logger = logger
-        self.localPeerInfo = peerID
-        self._remotePeerInfo = .init(nil)
-        self.expectedRemotePeerID = expectedRemotePeerID
-        self._state = .init(.awaitingPeerID)
-        self.channelSecuredCallback = secured
-        self._buffer = .init([])
     }
 
-    /// We take this opportunity to send our PeerExchange protobuf
     public func handlerAdded(context: ChannelHandlerContext) {
-        do {
-            self.logger.trace("Sending our local peer info to remote peer")
-
-            /// ----------------- Support Go ----------------
-            let peerInfo = try self.localPeerInfo.marshal()
-            /// ---------------------------
-
-            /// ----------------- Support JS ----------------
-            //let peerInfo = try createExchangeMessage(localPeerInfo)
-            /// ---------------------------
-
-            let payload = putUVarInt(UInt64(peerInfo.count)) + peerInfo
-
-            self.logger.trace("\(payload.asString(base: .base16))")
-            self.logger.trace("Count: \(payload.count)")
-
-            // Write the serialized data to a buffer
-            let buf = context.channel.allocator.buffer(bytes: payload)
-
-            // Send our peer info off to the remote host...
-            context.writeAndFlush(self.wrapOutboundOut(buf), promise: nil)
-
-        } catch {
-            self.logger.error("Failed to instantiate our PeerInfo Exchange protobuf")
-            self.logger.error("Error: \(error)")
-            self.logger.error("Closing Channel")
-            // TODO: We should probably fail better than this...
-            channelSecuredCallback.fail(error)
-            context.fireErrorCaught(error)
-            context.close(mode: .all, promise: nil)
+        if extraData.readableBytes > 0 {
+            self.logger.notice("Initialized with extra data!")
+            context.fireChannelRead(wrapInboundOut(extraData))
         }
     }
 
     public func channelRead(context: ChannelHandlerContext, data: NIOAny) {
-        switch state {
-        case .awaitingPeerID:
-            //We're expecting an Exchange Protobuf object thats uVarInt length Prefixed, if it's not that then we abort...
-            let buf = unwrapInboundIn(data)
-
-            let msg = buffer + [UInt8](buf.readableBytesView)
-            let prefix = uVarInt(msg)
-            guard prefix.bytesRead > 0, prefix.value > 1 else {
-                self.logger.error("Failed to parse inbound Plaintext/2.0.0 Handshake message")
-                channelSecuredCallback.fail(PlaintextErrors.invalidPeerIDExchange)
-                return context.close(mode: .all, promise: nil)
-            }
-
-            if prefix.value > msg.count {
-                //Partial Read Detected, waiting for more info!
-                buffer = msg
-                return
-            }
-
-            //msg = Array(msg.dropFirst(prefix.bytesRead))
-            let peerInfo = Array(msg[prefix.bytesRead..<(prefix.bytesRead + Int(prefix.value))])
-            let leftoverData = msg[(prefix.bytesRead + Int(prefix.value))...]
-
-            do {
-                logger.trace("\(peerInfo.asString(base: .base16))")
-                logger.trace("Bytes: \(peerInfo.count)")
-
-                let exchangeMessage = try Exchange(serializedBytes: peerInfo)
-                if let pid = try? PeerID(marshaledPeerID: Data(peerInfo)) {
-                    self.logger.trace("Incoming Message straight to PeerID (no exchange proto) => \(pid.b58String)")
-                    remotePeerInfo = pid
-                } else {
-                    remotePeerInfo = try PeerID(marshaledPublicKey: exchangeMessage.pubkey.data)  //.serializedData())
-                }
-
-                guard remotePeerInfo!.id == exchangeMessage.id.byteArray else {
-                    logger.error("Remote Peer ID isn't derived from their PublicKey. Closing connection.")
-                    //self.channelSecuredCallback.succeed((false, nil))
-                    self.channelSecuredCallback.fail(PlaintextErrors.invalidPeerIDExchange)
-                    return context.close(mode: .all, promise: nil)
-                }
-                if let expectedRemotePeerID {
-                    guard expectedRemotePeerID == remotePeerInfo else {
-                        logger.error("Remote Peer ID doesn't match our expected Peer ID. Closing connection.")
-                        self.channelSecuredCallback.fail(PlaintextErrors.unexpectedRemotePeer)
-                        return context.close(mode: .all, promise: nil)
-                    }
-                } else {
-                    logger.warning("Skipping Remote PeerID check as Expected PeerID was not provided")
-                }
-                logger.trace("Peer Info from Remote Peer seems legit, let's proceed")
-                logger.trace("PeerID: \(remotePeerInfo!.b58String)")
-                // Construct the Multiaddr that we know so far...
-                logger.trace(
-                    "RemoteAddress:Protocol => \(String(describing: context.channel.remoteAddress?.protocol ?? .none))"
-                )
-                logger.trace("RemoteAddress:Protocol => \(context.channel.remoteAddress?.ipAddress ?? "nil")")
-                logger.trace("RemoteAddress:Protocol => \(context.channel.remoteAddress?.port ?? -1)")
-                logger.trace("RemoteAddress:Protocol => \(context.channel.remoteAddress?.pathname ?? "nil")")
-
-                // Upgrade our state so that all future messages will be propogated through the pipeline
-                state = .verified
-
-                // Remove our uVarInt Length Prefix Handlers now that our handshake is complete. Then satisfy our channelSecuredCallback if all goes as planned.
-                self.channelSecuredCallback.succeed(
-                    (PlaintextUpgrader.key, self.remotePeerInfo, nil)
-                )
-
-                /// We cascade off of the channelSecuredCallback's futureResult to ensure the upgrader has had time to prepare the Pipeline before sending additional messages along it.
-                /// - Note: If we instead forwarded data along the pipeline in the completeWith handler above, MSS would get a channelRead before having time to finalize the security upgrade and prepare the muxer negotiator.
-                let _ = self.channelSecuredCallback.futureResult.always { _ in
-                    self.logger.trace("ChannelSecuredCallback futureResult.always called")
-                    if leftoverData.count > 0 {
-                        self.logger.trace("--- 🔓 Forwarding leftover handshake data 🔓 ---")
-                        context.fireChannelRead(
-                            self.wrapInboundOut(context.channel.allocator.buffer(bytes: leftoverData))
-                        )
-                    }
-                }
-            } catch {
-                logger.error("Failed to instantiate an Exchange Protobuf from the inbound data")
-                logger.error("Error: \(error)")
-                channelSecuredCallback.fail(error)
-                context.close(mode: .all, promise: nil)
-            }
-        case .verified:
-            // Simply forward the data along the pipeline
-            logger.trace("--- 🔓 Inbound Data Decryption Complete 🔓 ---")
-            context.fireChannelRead(wrapInboundOut(unwrapInboundIn(data)))
-        }
+        // Simply forward the data along the pipeline
+        logger.trace("--- 🔓 Inbound Data Decryption Complete 🔓 ---")
+        context.fireChannelRead(wrapInboundOut(unwrapInboundIn(data)))
     }
 
-    /// Given a peerID, this method handles building an Exchange protobuf
-    private func createExchangeMessage(_ peerID: PeerID) throws -> Data {
-        let keyType: Exchange.KeyType
-        switch peerID.keyPair!.keyType {
-        case .rsa:
-            keyType = .rsa
-        case .ed25519:
-            keyType = .ed25519
-        case .secp256k1:
-            keyType = .secp256K1
-        }
-
-        var pubkey = Exchange.PublicKey()
-        pubkey.type = keyType
-        pubkey.data = try Data(peerID.marshalPublicKey())
-
-        var exch = Exchange()
-        exch.id = Data(peerID.id)
-        exch.pubkey = pubkey
-
-        return try exch.serializedData()
+    public func channelReadComplete(context: ChannelHandlerContext) {
+        logger.trace("Read Complete")
+        // Propogate the message?
+        context.fireChannelReadComplete()
     }
 
-    public enum Errors: Error {
-        case failedToRemoveEphemeralHandshakeHandlersFromPipeline
+    public func errorCaught(context: ChannelHandlerContext, error: Error) {
+        logger.error("Error: \(error)")
+
+        context.close(promise: nil)
     }
 }

--- a/Sources/LibP2PPlaintext/LibP2PPlaintext.swift
+++ b/Sources/LibP2PPlaintext/LibP2PPlaintext.swift
@@ -43,6 +43,13 @@ public struct PlaintextUpgrader: SecurityUpgrader {
     }
 
     public func printSelf() {
-        application.logger.notice("Hi I'm the PlaintextV2 security protocol")
+        application.logger.notice("Hi I'm the PlaintextV2 (in)security protocol")
+    }
+}
+
+extension PlaintextUpgrader {
+    public enum Error: Swift.Error, Sendable {
+        case invalidPeerIDExchange
+        case unexpectedRemotePeer
     }
 }

--- a/Sources/LibP2PPlaintext/LibP2PPlaintext.swift
+++ b/Sources/LibP2PPlaintext/LibP2PPlaintext.swift
@@ -37,7 +37,7 @@ public struct PlaintextUpgrader: SecurityUpgrader {
                 logger: conn.logger,
                 secured: securedPromise,
                 expectedRemotePeerID: conn.expectedRemotePeer
-            ),
+            )
         ]
         return conn.channel.pipeline.addHandlers(handlers, position: position)
     }

--- a/Sources/LibP2PPlaintext/LibP2PPlaintext.swift
+++ b/Sources/LibP2PPlaintext/LibP2PPlaintext.swift
@@ -14,11 +14,6 @@
 
 import LibP2P
 
-public enum PlaintextErrors: Error {
-    case invalidPeerIDExchange
-    case unexpectedRemotePeer
-}
-
 public struct PlaintextUpgrader: SecurityUpgrader {
 
     public static let key: String = "/plaintext/2.0.0"
@@ -36,16 +31,12 @@ public struct PlaintextUpgrader: SecurityUpgrader {
     ) -> EventLoopFuture<Void> {
         // Given a ChannelHandlerContext Configure and Install our HandshakeHandler onto the pipeline
         let handlers: [ChannelHandler & Sendable] = [
-            InboundPlaintextV2DecryptHandler(
+            PlaintextV2HandshakeHandler(
                 peerID: conn.localPeer,
                 mode: conn.mode,
                 logger: conn.logger,
                 secured: securedPromise,
                 expectedRemotePeerID: conn.expectedRemotePeer
-            ),
-            OutboundPlaintextV2EncryptHandler(
-                mode: conn.mode,
-                logger: conn.logger
             ),
         ]
         return conn.channel.pipeline.addHandlers(handlers, position: position)

--- a/Tests/LibP2PPlaintextTests/IntegrationTests.swift
+++ b/Tests/LibP2PPlaintextTests/IntegrationTests.swift
@@ -44,8 +44,6 @@ struct InternalIntegrationTests {
 
         try await host.asyncShutdown()
         try await client.asyncShutdown()
-
-        print("Goodbye 👋")
     }
 
     @Test(arguments: [10, 100, 1_000])
@@ -80,8 +78,6 @@ struct InternalIntegrationTests {
 
         try await host.asyncShutdown()
         try await client.asyncShutdown()
-
-        print("Goodbye 👋")
     }
 
     // Executing a bunch of concurrent requests should cascade into a single connection when appropriate (using the same transport)
@@ -127,8 +123,6 @@ struct InternalIntegrationTests {
 
         try await host.asyncShutdown()
         try await client.asyncShutdown()
-
-        print("Goodbye 👋")
     }
 }
 
@@ -160,8 +154,6 @@ struct ExternalIntegrationTests {
         try await Task.sleep(for: .seconds(1))
 
         try await client.asyncShutdown()
-
-        print("Goodbye 👋")
     }
 
     /// **************************************
@@ -200,8 +192,6 @@ struct ExternalIntegrationTests {
         client.peers.dumpAll()
 
         try await client.asyncShutdown()
-
-        print("Goodbye 👋")
     }
 
     /// **************************************
@@ -255,8 +245,6 @@ struct ExternalIntegrationTests {
         client.peers.dumpAll()
 
         try await client.asyncShutdown()
-
-        print("Goodbye 👋")
     }
 }
 

--- a/Tests/LibP2PPlaintextTests/IntegrationTests.swift
+++ b/Tests/LibP2PPlaintextTests/IntegrationTests.swift
@@ -105,7 +105,7 @@ struct InternalIntegrationTests {
 
         let numberOfRequests = 3
 
-        try await withThrowingTaskGroup { group in
+        try await withThrowingTaskGroup(of: Void.self) { group in
             for index in 0..<numberOfRequests {
                 group.addTask {
                     /// Fire off an echo request

--- a/Tests/LibP2PPlaintextTests/IntegrationTests.swift
+++ b/Tests/LibP2PPlaintextTests/IntegrationTests.swift
@@ -55,7 +55,7 @@ struct InternalIntegrationTests {
 
         try await host.startup()
         try await client.startup()
-        
+
         for _ in 0..<numberOfRequests {
             /// Fire off an echo request
             let response = try await client.newRequest(


### PR DESCRIPTION
### What:
- Every once in a while we would fail to perform a handshake due to [data being dropped by the Upgrader](https://github.com/swift-libp2p/swift-libp2p/pull/37)

### Requires:
- swift-libp2p/swift-libp2p/pull/37

### Additional:
- Refactored our handshake
- We now have a `PlaintextV2HandshakeHandler` that...
   -  handles the handshake then
   - installs the inbound and outbound (decryption / encryption) handlers
   - then removes itself from the pipeline
   - This design is similar to how [swift-libp2p-noise](https://github.com/swift-libp2p/swift-libp2p-noise) handles the handshake
- Added additional tests

### Fixes: 
- #3 