### PR TITLE
Fix tests

### DIFF
--- a/Tests/LibP2PPlaintextTests/IntegrationTests.swift
+++ b/Tests/LibP2PPlaintextTests/IntegrationTests.swift
@@ -18,7 +18,7 @@ import Testing
 
 @testable import LibP2PPlaintext
 
-@Suite("Active Tests", .serialized)
+@Suite("Active Tests", .serialized, .timeLimit(.minutes(5)))
 struct InternalIntegrationTests {
     /// ***************************************
     /// Testing Internal Swift Interoperability


### PR DESCRIPTION
### What?
This PR hopefully makes CI testing less flakey by
- Adding a timeout to our test suite (in case of test hangs)
- Better error handling for clean shutdowns
- Reducing the number of sequential requests in `testInternalInteropMultipleRequests_Sequentially`